### PR TITLE
Fix roxygen2 @references tag and regenerate docs

### DIFF
--- a/R/calc_depth.R
+++ b/R/calc_depth.R
@@ -12,7 +12,7 @@
 #' Qs <- seq(1,9,2)
 #' calc_depth(Q=Qs)
 #' calc_depth(Q=Qs, f=0.4)
-#' #' @references Raymond, Peter A., Christopher J. Zappa, David Butman, Thomas L. 
+#' @references Raymond, Peter A., Christopher J. Zappa, David Butman, Thomas L. 
 #'   Bott, Jody Potter, Patrick Mulholland, Andrew E. Laursen, William H. 
 #'   McDowell, and Denis Newbold. \emph{Scaling the gas transfer velocity and 
 #'   hydraulic geometry in streams and small rivers}. Limnology & Oceanography: 

--- a/R/calc_velocity.R
+++ b/R/calc_velocity.R
@@ -12,7 +12,7 @@
 #' Qs <- seq(1,9,2)
 #' calc_velocity(Q=Qs)
 #' calc_velocity(Q=Qs, k=0.4)
-#' #' @references Raymond, Peter A., Christopher J. Zappa, David Butman, Thomas L. 
+#' @references Raymond, Peter A., Christopher J. Zappa, David Butman, Thomas L. 
 #'   Bott, Jody Potter, Patrick Mulholland, Andrew E. Laursen, William H. 
 #'   McDowell, and Denis Newbold. \emph{Scaling the gas transfer velocity and 
 #'   hydraulic geometry in streams and small rivers}. Limnology & Oceanography: 

--- a/R/mm_data.R
+++ b/R/mm_data.R
@@ -145,6 +145,9 @@ mm_data <- function(..., optional='none') {
     dat[.dotnames]
   }
 
+  # if dat is NULL (from passing NULL as ...), return NULL immediately
+  if(is.null(dat)) return(NULL)
+
   # add information about which columns, if any, are optional.
   optional <- if(missing(optional)) {
     if(isTRUE(.nulldot)) {

--- a/R/mm_model_by_ply.R
+++ b/R/mm_model_by_ply.R
@@ -96,7 +96,7 @@ mm_model_by_ply <- function(
     timegoof <- which.min(timesteps) + c(0,1)
     stop("min timestep is <= 0: ", format(min_timestep, digits=3), " days from ",
          data$solar.time[timegoof[1]], " (row ", timegoof[1], ") to ",
-         data$solar.time[timegoof[2]], " (row ", timegoof[2], ")"),
+         data$solar.time[timegoof[2]], " (row ", timegoof[2], ")")
   }
   if(!is.null(data_daily)) {
     if(!('date' %in% names(data_daily))) stop("data_daily must contain a 'date' column")
@@ -106,7 +106,7 @@ mm_model_by_ply <- function(
       timegoof <- which.min(timesteps) + c(0,1)
       stop("min datestep is <= 0: ", min_datestep, " days from ",
            data_daily$date[timegoof[1]], " (row ", timegoof[1], ") to ",
-           data_daily$date[timegoof[2]], " (row ", timegoof[2], ")"),
+           data_daily$date[timegoof[2]], " (row ", timegoof[2], ")")
     }
   }
   doyhr <- convert_date_to_doyhr(data.plys$solar.time)

--- a/man-roxygen/metab_data.R
+++ b/man-roxygen/metab_data.R
@@ -8,13 +8,13 @@
 #'   \item{\code{mle} or \code{night}}{
 #'     \tabular{llll}{
 #'       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-#'       solar.time        \tab POSIXct,POSIXt  \tab                 \tab required      \cr
-#'       DO.obs            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-#'       DO.sat            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-#'       depth             \tab numeric         \tab m               \tab required      \cr
-#'       temp.water        \tab numeric         \tab degC            \tab required      \cr
-#'       light             \tab numeric         \tab umol m^-2 s^-1  \tab required      \cr
-#'       discharge         \tab numeric         \tab m^3 s^-1        \tab optional      
+#'       solar.time        \tab POSIXct,POSIXt  \tab NA              \tab required      \cr
+#'       DO.obs            \tab numeric         \tab NA              \tab required      \cr
+#'       DO.sat            \tab numeric         \tab NA              \tab required      \cr
+#'       depth             \tab numeric         \tab NA              \tab required      \cr
+#'       temp.water        \tab numeric         \tab NA              \tab required      \cr
+#'       light             \tab numeric         \tab NA              \tab required      \cr
+#'       discharge         \tab numeric         \tab NA              \tab optional      
 #'     }
 #'     
 #'     \strong{Example}:
@@ -26,13 +26,13 @@
 #'   \item{\code{bayes}}{
 #'     \tabular{llll}{
 #'       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-#'       solar.time        \tab POSIXct,POSIXt  \tab                 \tab required      \cr
-#'       DO.obs            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-#'       DO.sat            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-#'       depth             \tab numeric         \tab m               \tab required      \cr
-#'       temp.water        \tab numeric         \tab degC            \tab required      \cr
-#'       light             \tab numeric         \tab umol m^-2 s^-1  \tab required      \cr
-#'       discharge         \tab numeric         \tab m^3 s^-1        \tab optional      
+#'       solar.time        \tab POSIXct,POSIXt  \tab NA              \tab required      \cr
+#'       DO.obs            \tab numeric         \tab NA              \tab required      \cr
+#'       DO.sat            \tab numeric         \tab NA              \tab required      \cr
+#'       depth             \tab numeric         \tab NA              \tab required      \cr
+#'       temp.water        \tab numeric         \tab NA              \tab required      \cr
+#'       light             \tab numeric         \tab NA              \tab required      \cr
+#'       discharge         \tab numeric         \tab NA              \tab optional      
 #'     }
 #'     
 #'     \strong{Example}:
@@ -44,9 +44,9 @@
 #'   \item{\code{Kmodel}}{
 #'     \tabular{llll}{
 #'       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-#'       solar.time        \tab POSIXct,POSIXt  \tab                 \tab optional      \cr
-#'       discharge         \tab numeric         \tab m^3 s^-1        \tab optional      \cr
-#'       velocity          \tab numeric         \tab m s^-1          \tab optional      
+#'       solar.time        \tab POSIXct,POSIXt  \tab NA              \tab optional      \cr
+#'       discharge         \tab numeric         \tab NA              \tab optional      \cr
+#'       velocity          \tab numeric         \tab NA              \tab optional      
 #'     }
 #'     
 #'     \strong{Example}:
@@ -58,12 +58,12 @@
 #'   \item{\code{sim}}{
 #'     \tabular{llll}{
 #'       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-#'       solar.time        \tab POSIXct,POSIXt  \tab                 \tab required      \cr
-#'       DO.obs            \tab numeric         \tab mgO2 L^-1       \tab optional      \cr
-#'       DO.sat            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-#'       depth             \tab numeric         \tab m               \tab required      \cr
-#'       temp.water        \tab numeric         \tab degC            \tab required      \cr
-#'       light             \tab numeric         \tab umol m^-2 s^-1  \tab required      
+#'       solar.time        \tab POSIXct,POSIXt  \tab NA              \tab required      \cr
+#'       DO.obs            \tab numeric         \tab NA              \tab optional      \cr
+#'       DO.sat            \tab numeric         \tab NA              \tab required      \cr
+#'       depth             \tab numeric         \tab NA              \tab required      \cr
+#'       temp.water        \tab numeric         \tab NA              \tab required      \cr
+#'       light             \tab numeric         \tab NA              \tab required      
 #'     }
 #'     
 #'     \strong{Example}:
@@ -85,15 +85,15 @@
 #'   }
 #'   \item{\code{mle}}{
 #'     \tabular{llll}{
-#'       \strong{colname} \tab \strong{class} \tab \strong{units}    \tab \strong{need}\cr
-#'       date              \tab Date            \tab                    \tab optional      \cr
-#'       K600.daily        \tab numeric         \tab d^-1               \tab optional      \cr
-#'       init.GPP.daily    \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-#'       init.Pmax         \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-#'       init.alpha        \tab numeric         \tab gO2 s d^-1 umol^-1 \tab optional      \cr
-#'       init.ER.daily     \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-#'       init.ER20         \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-#'       init.K600.daily   \tab numeric         \tab d^-1               \tab optional      
+#'       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
+#'       date              \tab Date            \tab NA              \tab optional      \cr
+#'       K600.daily        \tab numeric         \tab NA              \tab optional      \cr
+#'       init.GPP.daily    \tab numeric         \tab NA              \tab optional      \cr
+#'       init.Pmax         \tab numeric         \tab NA              \tab optional      \cr
+#'       init.alpha        \tab numeric         \tab NA              \tab optional      \cr
+#'       init.ER.daily     \tab numeric         \tab NA              \tab optional      \cr
+#'       init.ER20         \tab numeric         \tab NA              \tab optional      \cr
+#'       init.K600.daily   \tab numeric         \tab NA              \tab optional      
 #'     }
 #'     
 #'     \strong{Example}:
@@ -105,8 +105,8 @@
 #'   \item{\code{bayes}}{
 #'     \tabular{llll}{
 #'       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-#'       date              \tab Date            \tab                 \tab optional      \cr
-#'       discharge.daily   \tab numeric         \tab m^3 s^-1        \tab optional      
+#'       date              \tab Date            \tab NA              \tab optional      \cr
+#'       discharge.daily   \tab numeric         \tab NA              \tab optional      
 #'     }
 #'     
 #'     \strong{Example}:
@@ -118,12 +118,12 @@
 #'   \item{\code{Kmodel}}{
 #'     \tabular{llll}{
 #'       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-#'       date              \tab Date            \tab                 \tab required      \cr
-#'       K600.daily        \tab numeric         \tab d^-1            \tab required      \cr
-#'       K600.daily.lower  \tab numeric         \tab d^-1            \tab optional      \cr
-#'       K600.daily.upper  \tab numeric         \tab d^-1            \tab optional      \cr
-#'       discharge.daily   \tab numeric         \tab m^3 s^-1        \tab optional      \cr
-#'       velocity.daily    \tab numeric         \tab m s^-1          \tab optional      
+#'       date              \tab Date            \tab NA              \tab required      \cr
+#'       K600.daily        \tab numeric         \tab NA              \tab required      \cr
+#'       K600.daily.lower  \tab numeric         \tab NA              \tab optional      \cr
+#'       K600.daily.upper  \tab numeric         \tab NA              \tab optional      \cr
+#'       discharge.daily   \tab numeric         \tab NA              \tab optional      \cr
+#'       velocity.daily    \tab numeric         \tab NA              \tab optional      
 #'     }
 #'     
 #'     \strong{Example}:
@@ -134,20 +134,20 @@
 #'   }
 #'   \item{\code{sim}}{
 #'     \tabular{llll}{
-#'       \strong{colname} \tab \strong{class} \tab \strong{units}    \tab \strong{need}\cr
-#'       date              \tab Date            \tab                    \tab optional      \cr
-#'       discharge.daily   \tab numeric         \tab m^3 s^-1           \tab optional      \cr
-#'       DO.mod.1          \tab numeric         \tab mgO2 L^-1          \tab optional      \cr
-#'       K600.daily        \tab numeric         \tab d^-1               \tab optional      \cr
-#'       GPP.daily         \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-#'       Pmax              \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-#'       alpha             \tab numeric         \tab gO2 s d^-1 umol^-1 \tab optional      \cr
-#'       ER.daily          \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-#'       ER20              \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-#'       err.obs.sigma     \tab numeric         \tab mgO2 L^-1          \tab optional      \cr
-#'       err.obs.phi       \tab numeric         \tab                    \tab optional      \cr
-#'       err.proc.sigma    \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-#'       err.proc.phi      \tab numeric         \tab                    \tab optional      
+#'       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
+#'       date              \tab Date            \tab NA              \tab optional      \cr
+#'       discharge.daily   \tab numeric         \tab NA              \tab optional      \cr
+#'       DO.mod.1          \tab numeric         \tab NA              \tab optional      \cr
+#'       K600.daily        \tab numeric         \tab NA              \tab optional      \cr
+#'       GPP.daily         \tab numeric         \tab NA              \tab optional      \cr
+#'       Pmax              \tab numeric         \tab NA              \tab optional      \cr
+#'       alpha             \tab numeric         \tab NA              \tab optional      \cr
+#'       ER.daily          \tab numeric         \tab NA              \tab optional      \cr
+#'       ER20              \tab numeric         \tab NA              \tab optional      \cr
+#'       err.obs.sigma     \tab numeric         \tab NA              \tab optional      \cr
+#'       err.obs.phi       \tab numeric         \tab NA              \tab optional      \cr
+#'       err.proc.sigma    \tab numeric         \tab NA              \tab optional      \cr
+#'       err.proc.phi      \tab numeric         \tab NA              \tab optional      
 #'     }
 #'     
 #'     \strong{Example}:

--- a/man/calc_DO_deficit.Rd
+++ b/man/calc_DO_deficit.Rd
@@ -35,11 +35,5 @@ around. Creates a DO.deficit vector for input into metabolism models.
 \dontrun{
 # Warning: this function is deprecated.
 calc_DO_deficit(DO.obs=7, temp.water=25, pressure.air=900, salinity.water=2.43)
-library(unitted)
-calc_DO_deficit(
-  DO.obs = u(c(7,7.5,7),'mgO2 L^-1'),
-  temp.water = u(c(25,24.5,18.9), 'degC'),
-  pressure.air = u(c(900,903,910), 'mb'),
-  salinity.water = u(2.43, 'PSU'))
 }
 }

--- a/man/calc_DO_sat.Rd
+++ b/man/calc_DO_sat.Rd
@@ -8,7 +8,7 @@ supplied conditions}
 calc_DO_sat(
   temp.water,
   pressure.air,
-  salinity.water = u(0, "PSU"),
+  salinity.water = 0,
   model = "garcia-benson",
   ...
 )
@@ -39,7 +39,5 @@ Calculates the equilibrium saturation concentration of oxygen in water at the
 supplied conditions
 }
 \examples{
-calc_DO_sat(temp=21, press=1000.1, sal=0) # no units checking if no units provided
-library(unitted)
-calc_DO_sat(temp=u(21,"degC"), press=u(1000.1,"mb"), sal=u(0,"PSU")) # units are checked
+calc_DO_sat(temp=21, press=1000.1, sal=0)
 }

--- a/man/calc_air_pressure.Rd
+++ b/man/calc_air_pressure.Rd
@@ -4,11 +4,7 @@
 \alias{calc_air_pressure}
 \title{Calculates the average air pressure for a site}
 \usage{
-calc_air_pressure(
-  temp.air = u(15, "degC"),
-  elevation = u(762, "m"),
-  attach.units = deprecated()
-)
+calc_air_pressure(temp.air = 15, elevation = 762, attach.units = deprecated())
 }
 \arguments{
 \item{temp.air}{air temperature in degrees C. Default is 15 degC.}

--- a/man/calc_declination_angle.Rd
+++ b/man/calc_declination_angle.Rd
@@ -26,7 +26,7 @@ decdf <- data.frame(jday=1:366,
   dec=streamMetabolizer:::calc_declination_angle(1:366))
 \dontrun{
 library(ggplot2)
-ggplot(unitted::v(decdf), aes(x=jday, y=dec)) + geom_line()
+ggplot(decdf, aes(x=jday, y=dec)) + geom_line()
 }
 }
 \references{

--- a/man/calc_depth.Rd
+++ b/man/calc_depth.Rd
@@ -4,7 +4,7 @@
 \alias{calc_depth}
 \title{Estimate depth from discharge and hydraulic geometry coefficients}
 \usage{
-calc_depth(Q, c = u(0.409, "m"), f = u(0.294, ""))
+calc_depth(Q, c = 0.409, f = 0.294)
 }
 \arguments{
 \item{Q}{discharge (m^3 s^-1)}
@@ -25,9 +25,6 @@ Leopold and Maddock, 1953; default values for c and f as in Raymond et al.
 Qs <- seq(1,9,2)
 calc_depth(Q=Qs)
 calc_depth(Q=Qs, f=0.4)
-library(unitted)
-calc_depth(Q=u(Qs, "m^3 s^-1"), c=u(40,"cm"))
-calc_depth(Q=u(Qs, "m^3 s^-1"), f=u(0.36))
 }
 \references{
 Raymond, Peter A., Christopher J. Zappa, David Butman, Thomas L. 

--- a/man/calc_light.Rd
+++ b/man/calc_light.Rd
@@ -8,7 +8,7 @@ calc_light(
   solar.time,
   latitude,
   longitude,
-  max.PAR = u(2326, "umol m^-2 s^-1"),
+  max.PAR = 2326,
   attach.units = deprecated()
 )
 }
@@ -37,6 +37,4 @@ date-times and site coordinates.
 \examples{
 solar.time <- lubridate::force_tz(as.POSIXct('2016-09-27 12:00'), 'UTC')
 calc_light(solar.time, 40, -120)
-library(unitted)
-calc_light(u(solar.time), u(40, 'degN'), u(-120, 'degE'), u(2315, 'umol m^-2 s^-1'))
 }

--- a/man/calc_light_merged.Rd
+++ b/man/calc_light_merged.Rd
@@ -51,7 +51,6 @@ this as a way to smoothly interpolate a time series of observations.
 \dontrun{
 library(dplyr)
 library(ggplot2)
-library(unitted)
 timebounds <- as.POSIXct(c('2008-03-12 00:00', '2008-03-12 23:59'), tz='UTC')
 coords <- list(lat=32.4, lon=-96.5)
 PAR.obs <- tibble::tibble(
@@ -64,8 +63,8 @@ PAR.mod <- tibble::tibble(
 ) \%>\% as.data.frame()
 PAR.merged <- calc_light_merged(PAR.obs, PAR.mod$solar.time,
   latitude=coords$lat, longitude=coords$lon, max.gap=as.difftime(20, units='hours'))
-ggplot(bind_rows(mutate(v(PAR.obs), type='obs'), mutate(v(PAR.mod), type='mod'),
-                 mutate(v(PAR.merged), type='merged')) \%>\%
+ggplot(bind_rows(mutate(PAR.obs, type='obs'), mutate(PAR.mod, type='mod'),
+                 mutate(PAR.merged, type='merged')) \%>\%
        mutate(type=ordered(type, levels=c('obs','mod','merged'))),
   aes(x=solar.time, y=light, color=type)) + geom_line() + geom_point() + theme_bw()
 }

--- a/man/calc_velocity.Rd
+++ b/man/calc_velocity.Rd
@@ -4,7 +4,7 @@
 \alias{calc_velocity}
 \title{Estimate velocity from discharge and hydraulic geometry coefficients}
 \usage{
-calc_velocity(Q, k = u(0.194, "m s^-1"), m = u(0.285, ""))
+calc_velocity(Q, k = 0.194, m = 0.285)
 }
 \arguments{
 \item{Q}{discharge (m^3 s^-1)}
@@ -25,9 +25,6 @@ Leopold and Maddock, 1953; default values for k and m as in Raymond et al.
 Qs <- seq(1,9,2)
 calc_velocity(Q=Qs)
 calc_velocity(Q=Qs, k=0.4)
-library(unitted)
-calc_velocity(Q=u(Qs, "m^3 s^-1"), m=u(40))
-calc_velocity(Q=u(Qs, "m^3 s^-1"), k=u(0.36, "m s^-1"))
 }
 \references{
 Raymond, Peter A., Christopher J. Zappa, David Butman, Thomas L. 

--- a/man/calc_zenith_angle.Rd
+++ b/man/calc_zenith_angle.Rd
@@ -41,7 +41,7 @@ zendf <- transform(zendf,
   zen=streamMetabolizer:::calc_zenith_angle(lat, dec, hragl))
 \dontrun{
 library(ggplot2)
-ggplot(unitted::v(zendf), aes(x=hour, y=zen, color=jday, group=jday)) +
+ggplot(zendf, aes(x=hour, y=zen, color=jday, group=jday)) +
   geom_line() + facet_wrap(~lat) +
   ggtitle('zenith angles by latitude (panels) and day of year (colors)')
 }

--- a/man/convert_PAR_to_SW.Rd
+++ b/man/convert_PAR_to_SW.Rd
@@ -23,5 +23,5 @@ changes in this ratio (see Britton and Dodd (1976)).
 }
 \examples{
 convert_PAR_to_SW(par=400, coef=0.47)
-convert_PAR_to_SW(unitted::u(1000, "umol m^-2 s^-1"))
+convert_PAR_to_SW(1000)
 }

--- a/man/convert_SW_to_PAR.Rd
+++ b/man/convert_SW_to_PAR.Rd
@@ -23,5 +23,5 @@ changes in this ratio (see Britton and Dodd (1976)).
 \examples{
 convert_SW_to_PAR(sw=800)
 convert_SW_to_PAR(sw=800, coef=2.1)
-convert_SW_to_PAR(unitted::u(473, "W m^-2"))
+convert_SW_to_PAR(473)
 }

--- a/man/lookup_google_timezone.Rd
+++ b/man/lookup_google_timezone.Rd
@@ -7,8 +7,8 @@
 lookup_google_timezone(
   latitude,
   longitude,
-  timestamp = if (unitted::v(latitude) >= 0) as.POSIXct("2015-01-01 00:00:00", tz =
-    "UTC") else as.POSIXct("2015-07-01 00:00:00", tz = "UTC")
+  timestamp = if (latitude >= 0) as.POSIXct("2015-01-01 00:00:00", tz = "UTC") else
+    as.POSIXct("2015-07-01 00:00:00", tz = "UTC")
 )
 }
 \arguments{

--- a/man/metab.Rd
+++ b/man/metab.Rd
@@ -6,8 +6,8 @@
 \usage{
 metab(
   specs = specs(mm_name()),
-  data = v(mm_data(NULL)),
-  data_daily = v(mm_data(NULL)),
+  data = mm_data(NULL),
+  data_daily = mm_data(NULL),
   info = NULL
 )
 }
@@ -53,13 +53,13 @@ depend on the model \code{type}, as follows.
   \item{\code{mle} or \code{night}}{
     \tabular{llll}{
       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-      solar.time        \tab POSIXct,POSIXt  \tab                 \tab required      \cr
-      DO.obs            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-      DO.sat            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-      depth             \tab numeric         \tab m               \tab required      \cr
-      temp.water        \tab numeric         \tab degC            \tab required      \cr
-      light             \tab numeric         \tab umol m^-2 s^-1  \tab required      \cr
-      discharge         \tab numeric         \tab m^3 s^-1        \tab optional      
+      solar.time        \tab POSIXct,POSIXt  \tab NA              \tab required      \cr
+      DO.obs            \tab numeric         \tab NA              \tab required      \cr
+      DO.sat            \tab numeric         \tab NA              \tab required      \cr
+      depth             \tab numeric         \tab NA              \tab required      \cr
+      temp.water        \tab numeric         \tab NA              \tab required      \cr
+      light             \tab numeric         \tab NA              \tab required      \cr
+      discharge         \tab numeric         \tab NA              \tab optional      
     }
     
     \strong{Example}:
@@ -71,13 +71,13 @@ depend on the model \code{type}, as follows.
   \item{\code{bayes}}{
     \tabular{llll}{
       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-      solar.time        \tab POSIXct,POSIXt  \tab                 \tab required      \cr
-      DO.obs            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-      DO.sat            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-      depth             \tab numeric         \tab m               \tab required      \cr
-      temp.water        \tab numeric         \tab degC            \tab required      \cr
-      light             \tab numeric         \tab umol m^-2 s^-1  \tab required      \cr
-      discharge         \tab numeric         \tab m^3 s^-1        \tab optional      
+      solar.time        \tab POSIXct,POSIXt  \tab NA              \tab required      \cr
+      DO.obs            \tab numeric         \tab NA              \tab required      \cr
+      DO.sat            \tab numeric         \tab NA              \tab required      \cr
+      depth             \tab numeric         \tab NA              \tab required      \cr
+      temp.water        \tab numeric         \tab NA              \tab required      \cr
+      light             \tab numeric         \tab NA              \tab required      \cr
+      discharge         \tab numeric         \tab NA              \tab optional      
     }
     
     \strong{Example}:
@@ -89,9 +89,9 @@ depend on the model \code{type}, as follows.
   \item{\code{Kmodel}}{
     \tabular{llll}{
       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-      solar.time        \tab POSIXct,POSIXt  \tab                 \tab optional      \cr
-      discharge         \tab numeric         \tab m^3 s^-1        \tab optional      \cr
-      velocity          \tab numeric         \tab m s^-1          \tab optional      
+      solar.time        \tab POSIXct,POSIXt  \tab NA              \tab optional      \cr
+      discharge         \tab numeric         \tab NA              \tab optional      \cr
+      velocity          \tab numeric         \tab NA              \tab optional      
     }
     
     \strong{Example}:
@@ -103,12 +103,12 @@ depend on the model \code{type}, as follows.
   \item{\code{sim}}{
     \tabular{llll}{
       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-      solar.time        \tab POSIXct,POSIXt  \tab                 \tab required      \cr
-      DO.obs            \tab numeric         \tab mgO2 L^-1       \tab optional      \cr
-      DO.sat            \tab numeric         \tab mgO2 L^-1       \tab required      \cr
-      depth             \tab numeric         \tab m               \tab required      \cr
-      temp.water        \tab numeric         \tab degC            \tab required      \cr
-      light             \tab numeric         \tab umol m^-2 s^-1  \tab required      
+      solar.time        \tab POSIXct,POSIXt  \tab NA              \tab required      \cr
+      DO.obs            \tab numeric         \tab NA              \tab optional      \cr
+      DO.sat            \tab numeric         \tab NA              \tab required      \cr
+      depth             \tab numeric         \tab NA              \tab required      \cr
+      temp.water        \tab numeric         \tab NA              \tab required      \cr
+      light             \tab numeric         \tab NA              \tab required      
     }
     
     \strong{Example}:
@@ -133,15 +133,15 @@ depend on the model \code{type}, as follows.
   }
   \item{\code{mle}}{
     \tabular{llll}{
-      \strong{colname} \tab \strong{class} \tab \strong{units}    \tab \strong{need}\cr
-      date              \tab Date            \tab                    \tab optional      \cr
-      K600.daily        \tab numeric         \tab d^-1               \tab optional      \cr
-      init.GPP.daily    \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-      init.Pmax         \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-      init.alpha        \tab numeric         \tab gO2 s d^-1 umol^-1 \tab optional      \cr
-      init.ER.daily     \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-      init.ER20         \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-      init.K600.daily   \tab numeric         \tab d^-1               \tab optional      
+      \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
+      date              \tab Date            \tab NA              \tab optional      \cr
+      K600.daily        \tab numeric         \tab NA              \tab optional      \cr
+      init.GPP.daily    \tab numeric         \tab NA              \tab optional      \cr
+      init.Pmax         \tab numeric         \tab NA              \tab optional      \cr
+      init.alpha        \tab numeric         \tab NA              \tab optional      \cr
+      init.ER.daily     \tab numeric         \tab NA              \tab optional      \cr
+      init.ER20         \tab numeric         \tab NA              \tab optional      \cr
+      init.K600.daily   \tab numeric         \tab NA              \tab optional      
     }
     
     \strong{Example}:
@@ -153,8 +153,8 @@ depend on the model \code{type}, as follows.
   \item{\code{bayes}}{
     \tabular{llll}{
       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-      date              \tab Date            \tab                 \tab optional      \cr
-      discharge.daily   \tab numeric         \tab m^3 s^-1        \tab optional      
+      date              \tab Date            \tab NA              \tab optional      \cr
+      discharge.daily   \tab numeric         \tab NA              \tab optional      
     }
     
     \strong{Example}:
@@ -166,12 +166,12 @@ depend on the model \code{type}, as follows.
   \item{\code{Kmodel}}{
     \tabular{llll}{
       \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
-      date              \tab Date            \tab                 \tab required      \cr
-      K600.daily        \tab numeric         \tab d^-1            \tab required      \cr
-      K600.daily.lower  \tab numeric         \tab d^-1            \tab optional      \cr
-      K600.daily.upper  \tab numeric         \tab d^-1            \tab optional      \cr
-      discharge.daily   \tab numeric         \tab m^3 s^-1        \tab optional      \cr
-      velocity.daily    \tab numeric         \tab m s^-1          \tab optional      
+      date              \tab Date            \tab NA              \tab required      \cr
+      K600.daily        \tab numeric         \tab NA              \tab required      \cr
+      K600.daily.lower  \tab numeric         \tab NA              \tab optional      \cr
+      K600.daily.upper  \tab numeric         \tab NA              \tab optional      \cr
+      discharge.daily   \tab numeric         \tab NA              \tab optional      \cr
+      velocity.daily    \tab numeric         \tab NA              \tab optional      
     }
     
     \strong{Example}:
@@ -182,20 +182,20 @@ depend on the model \code{type}, as follows.
   }
   \item{\code{sim}}{
     \tabular{llll}{
-      \strong{colname} \tab \strong{class} \tab \strong{units}    \tab \strong{need}\cr
-      date              \tab Date            \tab                    \tab optional      \cr
-      discharge.daily   \tab numeric         \tab m^3 s^-1           \tab optional      \cr
-      DO.mod.1          \tab numeric         \tab mgO2 L^-1          \tab optional      \cr
-      K600.daily        \tab numeric         \tab d^-1               \tab optional      \cr
-      GPP.daily         \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-      Pmax              \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-      alpha             \tab numeric         \tab gO2 s d^-1 umol^-1 \tab optional      \cr
-      ER.daily          \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-      ER20              \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-      err.obs.sigma     \tab numeric         \tab mgO2 L^-1          \tab optional      \cr
-      err.obs.phi       \tab numeric         \tab                    \tab optional      \cr
-      err.proc.sigma    \tab numeric         \tab gO2 d^-1 m^-2      \tab optional      \cr
-      err.proc.phi      \tab numeric         \tab                    \tab optional      
+      \strong{colname} \tab \strong{class} \tab \strong{units} \tab \strong{need}\cr
+      date              \tab Date            \tab NA              \tab optional      \cr
+      discharge.daily   \tab numeric         \tab NA              \tab optional      \cr
+      DO.mod.1          \tab numeric         \tab NA              \tab optional      \cr
+      K600.daily        \tab numeric         \tab NA              \tab optional      \cr
+      GPP.daily         \tab numeric         \tab NA              \tab optional      \cr
+      Pmax              \tab numeric         \tab NA              \tab optional      \cr
+      alpha             \tab numeric         \tab NA              \tab optional      \cr
+      ER.daily          \tab numeric         \tab NA              \tab optional      \cr
+      ER20              \tab numeric         \tab NA              \tab optional      \cr
+      err.obs.sigma     \tab numeric         \tab NA              \tab optional      \cr
+      err.obs.phi       \tab numeric         \tab NA              \tab optional      \cr
+      err.proc.sigma    \tab numeric         \tab NA              \tab optional      \cr
+      err.proc.phi      \tab numeric         \tab NA              \tab optional      
     }
     
     \strong{Example}:

--- a/man/mm_data.Rd
+++ b/man/mm_data.Rd
@@ -20,7 +20,7 @@ column names are given, those columns may be omitted entirely or passed to
 data data.frame with columns as in the description
 }
 \description{
-Produces a unitted data.frame with the column names, units, and
+Produces a data.frame with the column names and
   data format to be used by metab_models that comply strictly with the
   metab_model_interface. These are the columns that may be included:
 

--- a/man/mm_model_by_ply_prototype.Rd
+++ b/man/mm_model_by_ply_prototype.Rd
@@ -5,8 +5,8 @@
 \title{A prototype for the model_fun argument to mm_model_by_ply}
 \usage{
 mm_model_by_ply_prototype(
-  data_ply = v(mm_data(NULL)),
-  data_daily_ply = v(mm_data(NULL)),
+  data_ply = mm_data(NULL),
+  data_daily_ply = mm_data(NULL),
   day_start = NA,
   day_end = NA,
   ply_date = NA,


### PR DESCRIPTION
Remove extra '#' ' prefix from @references tags in calc_depth.R and calc_velocity.R that was causing roxygen2 to treat references as example code rather than a doc tag. Regenerate .Rd files to reflect the fix.

Also includes previously staged changes:
- Add NULL guard in mm_data() to handle NULL input gracefully
- Remove trailing commas after stop() calls in mm_model_by_ply()
- Remove all unitted package references from documentation